### PR TITLE
[REC-84] chore: bump version of the Android SDK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,6 @@ dependencies {
     // Required Dependency for the Tracker
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.snowplowanalytics:snowplow-android-tracker:1.3.0@aar'
+    implementation 'com.snowplowanalytics:snowplow-android-tracker:1.4.0@aar'
 }
   


### PR DESCRIPTION
### Description
The object of this pull request it is just to bump the version of the android sdk from snowplow, because the play store emit some warning about the old version will be deprecated in the next month.

Deprecated Current version: [1.3.x](https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/mobile-trackers/previous-versions/android-tracker/android-1-3-0/)
New version: [1.4.0](https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/mobile-trackers/previous-versions/android-tracker/android-1-4-0/)